### PR TITLE
Add BATS test for load script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ sudo pacman -S \
     remmina $ RDP
     nitrogen # for wallpaper
 ```
+
+### Running BATS tests
+
+Install the `bats` executable and then run:
+
+```
+bats tests
+```
+

--- a/tests/check-sys-load.bats
+++ b/tests/check-sys-load.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+@test "check-sys-load prints load averages" {
+  run "$BATS_TEST_DIRNAME/../bin/check-sys-load"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "1-minute"
+  echo "$output" | grep -q "2-minute"
+  echo "$output" | grep -q "3-minute"
+}
+


### PR DESCRIPTION
## Summary
- add a simple BATS test for `bin/check-sys-load`
- document how to run the BATS test suite

## Testing
- `bats tests/check-sys-load.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444b0b9cfc832f8aa3f66fb6e77d88