### PR TITLE
Add flake outputs for host builds

### DIFF
--- a/nixos/README.md
+++ b/nixos/README.md
@@ -1,0 +1,32 @@
+# NixOS Quick Start Configuration
+
+This directory contains a basic NixOS flake that references the dotfiles in this repo.
+It defines several host configurations for different machines:
+
+- **dev** – personal development machine
+- **home** – home desktop
+- **server** – server configuration
+- **work** – work development machine (uses a separate user `workdev`)
+
+Each host imports common settings from `modules/common.nix` and optional desktop
+settings from `modules/desktop.nix`. User dotfiles are linked via
+`modules/home.nix` so that your `bin/` and `config/` directories are available
+on every machine.
+
+To build a configuration, run for example:
+
+```bash
+nix build .#nixosConfigurations.dev.config.system.build.toplevel
+```
+
+With the new flake outputs you can also use the shorter syntax:
+
+```bash
+nix build .#dev
+```
+
+Adjust the `system` attribute in `flake.nix` if your machines use another
+architecture.
+
+Hardware-specific settings can be placed in files under `hosts/` named
+`hardware-<host>.nix` and imported from each host configuration.

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Quick start NixOS config from dotfiles";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, home-manager, ... }@inputs:
+    let
+      lib = nixpkgs.lib;
+      inherit (nixpkgs) pkgs;
+    in
+    {
+      formatter.x86_64-linux = pkgs.nixpkgs-fmt;
+      nixosConfigurations = {
+        dev = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            ./hosts/dev.nix
+            home-manager.nixosModules.home-manager
+          ];
+          specialArgs = { inherit inputs; };
+        };
+
+        home = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            ./hosts/home.nix
+            home-manager.nixosModules.home-manager
+          ];
+          specialArgs = { inherit inputs; };
+        };
+
+        server = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            ./hosts/server.nix
+            home-manager.nixosModules.home-manager
+          ];
+          specialArgs = { inherit inputs; };
+        };
+
+        work = lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            ./hosts/work.nix
+            home-manager.nixosModules.home-manager
+          ];
+          specialArgs = { inherit inputs; };
+        };
+      };
+
+      packages.x86_64-linux = let cfgs = self.nixosConfigurations; in {
+        dev = cfgs.dev.config.system.build.toplevel;
+        home = cfgs.home.config.system.build.toplevel;
+        server = cfgs.server.config.system.build.toplevel;
+        work = cfgs.work.config.system.build.toplevel;
+      };
+    };
+}

--- a/nixos/hosts/dev.nix
+++ b/nixos/hosts/dev.nix
@@ -1,0 +1,17 @@
+{ inputs, pkgs, ... }:
+{
+  imports = [
+    ../modules/common.nix
+    ../modules/desktop.nix
+  ];
+
+  networking.hostName = "dev";
+
+  users.users.coder = {
+    isNormalUser = true;
+    description = "Personal development user";
+    extraGroups = [ "wheel" "networkmanager" "docker" ];
+  };
+
+  home-manager.users.coder = import ../modules/home.nix { inherit pkgs; };
+}

--- a/nixos/hosts/home.nix
+++ b/nixos/hosts/home.nix
@@ -1,0 +1,17 @@
+{ inputs, pkgs, ... }:
+{
+  imports = [
+    ../modules/common.nix
+    ../modules/desktop.nix
+  ];
+
+  networking.hostName = "home";
+
+  users.users.coder = {
+    isNormalUser = true;
+    description = "Home user";
+    extraGroups = [ "wheel" "networkmanager" ];
+  };
+
+  home-manager.users.coder = import ../modules/home.nix { inherit pkgs; };
+}

--- a/nixos/hosts/server.nix
+++ b/nixos/hosts/server.nix
@@ -1,0 +1,17 @@
+{ inputs, pkgs, ... }:
+{
+  imports = [
+    ../modules/common.nix
+  ];
+
+  networking.hostName = "server";
+  services.openssh.enable = true;
+
+  users.users.coder = {
+    isNormalUser = true;
+    description = "Server admin";
+    extraGroups = [ "wheel" ];
+  };
+
+  home-manager.users.coder = import ../modules/home.nix { inherit pkgs; };
+}

--- a/nixos/hosts/work.nix
+++ b/nixos/hosts/work.nix
@@ -1,0 +1,17 @@
+{ inputs, pkgs, ... }:
+{
+  imports = [
+    ../modules/common.nix
+    ../modules/desktop.nix
+  ];
+
+  networking.hostName = "work";
+
+  users.users.workdev = {
+    isNormalUser = true;
+    description = "Work development user";
+    extraGroups = [ "wheel" "networkmanager" "docker" ];
+  };
+
+  home-manager.users.workdev = import ../modules/home.nix { inherit pkgs; };
+}

--- a/nixos/modules/common.nix
+++ b/nixos/modules/common.nix
@@ -1,0 +1,36 @@
+{ config, pkgs, ... }:
+{
+  networking.networkmanager.enable = true;
+  time.timeZone = "UTC";
+  i18n.defaultLocale = "en_US.UTF-8";
+  nixpkgs.config.allowUnfree = true;
+
+  # Use zsh as default shell
+  users.defaultUserShell = pkgs.zsh;
+
+  # Basic packages shared across machines
+  environment.systemPackages = with pkgs; [
+    git
+    neovim
+    tmux
+    fzf
+    ripgrep
+    fd
+    wget
+    curl
+    starship
+    htop
+  ];
+
+  programs.zsh.enable = true;
+  programs.tmux.enable = true;
+  programs.ssh.startAgent = true;
+  virtualisation.docker.enable = true;
+  services.tailscale.enable = true;
+
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 7d";
+  };
+}

--- a/nixos/modules/desktop.nix
+++ b/nixos/modules/desktop.nix
@@ -1,0 +1,23 @@
+{ config, pkgs, ... }:
+{
+  services.xserver.enable = true;
+  services.xserver.desktopManager = {
+    xterm.enable = false;
+  };
+  programs.hyprland.enable = true;
+  services.displayManager.sddm.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    firefox
+    alacritty
+    rofi
+    waybar
+    mako
+    grim slurp swappy
+    cliphist
+    copyq
+    wl-clipboard
+    xclip
+    nerdfonts
+  ];
+}

--- a/nixos/modules/home.nix
+++ b/nixos/modules/home.nix
@@ -1,0 +1,37 @@
+{ pkgs, ... }:
+{
+  home.stateVersion = "23.11";
+
+  home.packages = with pkgs; [
+    git
+    neovim
+    tmux
+    fzf
+    ripgrep
+    fd
+    starship
+    zsh
+  ];
+
+  programs.zsh.enable = true;
+  programs.git.enable = true;
+  programs.neovim.enable = true;
+  programs.tmux.enable = true;
+  programs.starship = {
+    enable = true;
+  };
+
+  home.file.".config" = {
+    source = ../../config;
+    recursive = true;
+  };
+
+  home.file.".local/bin" = {
+    source = ../../bin;
+    recursive = true;
+  };
+
+  home.file.".ssh/config" = {
+    source = ../../ssh/config;
+  };
+}


### PR DESCRIPTION
## Summary
- add package outputs to `flake.nix` for each host
- note the shorter build syntax in README

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684452d390c4832fad51638356b362e3